### PR TITLE
Исправлена ошибка с некорректным отображением невалидированных полей формы

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -149,10 +149,9 @@ Array.prototype.slice.call(forms)
         }
       }
       if (form.checkValidity()) {
+        form.classList.add('was-validated')
         serializeForm(form);
       }
-
-      form.classList.add('was-validated')
     }, false)
   })
 


### PR DESCRIPTION
Там проблема была в классе "was-validated" самой формы. Его нужно добавлять только, если валидация прошла успешно.

Поэтому перенес присвоение этого класса внутрь условия.